### PR TITLE
Fix german languagetool translation

### DIFF
--- a/sdkjs-plugins/content/languagetool/translations/de-DE.json
+++ b/sdkjs-plugins/content/languagetool/translations/de-DE.json
@@ -3,6 +3,6 @@
 	"Check": "Prüfen",
 	"Insert to document": "In Dokument einfügen",
 	"Dismiss": "Überspringen",
-	"Clear": "Klar",
+	"Clear": "Leeren",
 	"Language": "Sprache"
 }


### PR DESCRIPTION
Fix for incorrect German LanguageTool translation.
To "clear" the input is probably best translated with "Leeren".
The previous "Klar" is the incorrect translation in this context.