### PR TITLE
Update Dutch translations in nl-NL.json

### DIFF
--- a/sdkjs-plugins/content/languagetool/translations/nl-NL.json
+++ b/sdkjs-plugins/content/languagetool/translations/nl-NL.json
@@ -1,8 +1,8 @@
 {
-	"Checking...": "Examen...",
-	"Check": "Rekening",
+	"Checking...": "Controleren...",
+	"Check": "Controleer",
 	"Insert to document": "Invoegen in document",
-	"Dismiss": "Skip",
-	"Clear": "Duidelijk",
+	"Dismiss": "Annuleer",
+	"Clear": "Verwijder",
 	"Language": "Taal"
 }


### PR DESCRIPTION
The translations as they are now (version 1.0.4 of the plug-in) are obviously done by some (bad) translation engine. "Check" is translated as something like "Bankaccount" if translated back to English. These are better and commonly used in applications.