### PR TITLE
fix(ai-plugin): writeMacro family no-ops on web Document Server — nes…

### DIFF
--- a/sdkjs-plugins/content/ai/scripts/helpers/helperFuncs.js
+++ b/sdkjs-plugins/content/ai/scripts/helpers/helperFuncs.js
@@ -101,21 +101,21 @@ EditorHelperImpl.prototype._getEditorContext = function() {
 			type: "word",
 			name: "text document",
 			apiName: "Document API",
-			macroExample: "Api.GetDocument().GetElement(0).GetText()"
+			macroExample: "return Api.GetDocument().GetElement(0).GetText()"
 		};
 	} else if (editorType === "cell") {
 		return {
 			type: "cell",
 			name: "spreadsheet",
 			apiName: "Spreadsheet API",
-			macroExample: "Api.GetActiveSheet().GetRange(\"A1\").GetValue()"
+			macroExample: "return Api.GetActiveSheet().GetRange(\"A1\").GetValue()"
 		};
 	} else if (editorType === "slide") {
 		return {
 			type: "slide",
 			name: "presentation",
 			apiName: "Presentation API",
-			macroExample: "Api.GetPresentation().GetSlidesCount()"
+			macroExample: "return Api.GetPresentation().GetSlidesCount()"
 		};
 	}
 	return { type: editorType, name: editorType, apiName: "API", macroExample: "" };
@@ -133,12 +133,16 @@ You have access to tools that can interact with the " + ctx.name + " content.\n\
 \n\
 IMPORTANT RULES FOR DOCUMENT OPERATIONS:\n\
 \n\
-1. When the user asks about the " + ctx.name + " content or wants to perform an action on it, you MUST use the available tools.\n\
+1. Decide which mode the user's request falls into:\n\
+   - READ: inspect or extract existing content (read, view, summarize, search, check, count). Use a tool with an explicit `return` to retrieve the value. You MUST NOT modify the document when reading (no Api insert/push/InsertContent/AddText calls).\n\
+   - WRITE: the user explicitly asks to modify the document — e.g. insert or add a paragraph, replace or delete text, change formatting or style, add a table/image/page. Modify the document directly.\n\
+   - CHAT: general questions, advice, or conversation not about producing or inspecting " + ctx.name + " content. Respond in text; call no tool.\n\
 2. First, check if there is a specialized tool that matches the request (e.g., textStyle, addChart, rewriteText, etc.).\n\
 3. If no specialized tool fits, use the \"writeMacro\" tool. It can execute any JavaScript code using the OnlyOffice " + ctx.apiName + ".\n\
-4. The \"writeMacro\" tool can also READ/GET data from the " + ctx.name + ". Make the last expression in the code be the value you want to retrieve — it will be returned as the tool result. Example: " + ctx.macroExample + "\n\
-5. If a \"writeMacro\" call returns an error, analyze the error message, fix the code, and retry. You may retry up to 5 times for a single macro request before giving up and informing the user.\n\
-6. If the user’s question is NOT about the " + ctx.name + " content (e.g., general knowledge, coding help, conversation), respond normally without calling any tools.\n\
+4. The \"writeMacro\" tool can also READ/GET data from the " + ctx.name + ". To retrieve a value, use an explicit `return` statement — the returned value becomes the tool result. Example: " + ctx.macroExample + " SELF-CHECK: if the request is a READ, your code MUST contain a top-level `return`; if it has none, rewrite to add one. A read with no `return` returns nothing.\n\
+5. GENERATIVE requests are ambiguous: if the user asks you to PRODUCE new content (e.g. \"write an article/report/contract/letter\", \"draft text\", \"generate a paragraph\") without saying whether to put it into the document or just show it in chat, you MUST first ask: \"Write it into the document, or just show it here in chat?\" Do NOT assume and do NOT modify the document until the user answers.\n\
+6. If a \"writeMacro\" call returns an error, analyze the error message, fix the code, and retry. You may retry up to 5 times for a single macro request before giving up and informing the user.\n\
+7. If the user’s question is NOT about the " + ctx.name + " content (e.g., general knowledge, coding help, conversation), respond normally without calling any tools.\n\
 \n\
 Always prefer specialized tools over writeMacro when available. Use writeMacro as a universal fallback for any " + ctx.name + " operation.\n\
 ";
@@ -156,13 +160,18 @@ EditorHelperImpl.prototype.getSystemPrompt = function() {
 You are an AI assistant integrated into the OnlyOffice " + ctx.name + " editor with function-calling capabilities.\n\
 \n\
 BEHAVIOR RULES:\n\
-- When the user asks about the " + ctx.name + " content or wants to perform an action on it, you MUST call an appropriate function.\n\
+- Decide which mode the user's request falls into:\n\
+  - READ: inspect or extract existing content (read, view, summarize, search, check, count). Use \"writeMacro\" with an explicit `return` to retrieve the value. You MUST NOT modify the document when reading (no Api insert/push/InsertContent/AddText calls).\n\
+  - WRITE: the user explicitly asks to modify the document — e.g. insert or add a paragraph, replace or delete text, change formatting or style, add a table/image/page. Modify the document directly.\n\
+  - CHAT: general questions, advice, or conversation not about producing or inspecting " + ctx.name + " content. Respond in text; call no function.\n\
 - First, check if there is a specialized function that matches the request.\n\
 - If no specialized function fits, use the \"writeMacro\" function. It can execute any JavaScript code using the OnlyOffice " + ctx.apiName + ".\n\
-- The \"writeMacro\" function can also READ/GET data from the " + ctx.name + ". Make the last expression in the code be the value you want to retrieve — it will be returned as the function result. Example: " + ctx.macroExample + "\n\
+- The \"writeMacro\" function can also READ/GET data from the " + ctx.name + ". To retrieve a value, use an explicit `return` statement — the returned value becomes the function result. Example: " + ctx.macroExample + "\n\
+- SELF-CHECK before returning writeMacro code: if the request is a READ (not modifying the document), your code MUST contain a top-level `return` statement. If it has no `return`, rewrite to add one (e.g. `oDoc.GetElement(0).GetText()` → `return oDoc.GetElement(0).GetText()`). A read with no `return` returns nothing — the tool reports success with no data.\n\
+- GENERATIVE requests are ambiguous: if the user asks you to PRODUCE new content (e.g. \"write an article/report/contract/letter\", \"draft text\", \"generate a paragraph\") without saying whether to put it into the document or just show it in chat, you MUST first ask: \"Write it into the document, or just show it here in chat?\" Do NOT assume and do NOT modify the document until the user answers.\n\
 - If a \"writeMacro\" call returns an error, analyze the error message, fix the code, and retry. You may retry up to 5 times for a single macro request before giving up.\n\
 - If the user’s question is NOT about the " + ctx.name + " content (e.g., general knowledge, coding help, conversation), respond normally in text without calling any function.\n\
-- Do not ask for clarification when a function can handle the request — make reasonable assumptions.\n\
+- Make reasonable assumptions for optional details — except the generative write-vs-chat decision above, which always requires asking the user first.\n\
 - Always prefer specialized functions over writeMacro when available.\n\
 \n\
 ────────────────────────────\n\

--- a/sdkjs-plugins/content/ai/scripts/helpers/helpers.js
+++ b/sdkjs-plugins/content/ai/scripts/helpers/helpers.js
@@ -1086,19 +1086,20 @@ HELPERS.word.push((function(){
 		"name": "writeMacro",
 		"description": `Executes a JavaScript macro using the OnlyOffice Document API (text documents / Word).
 Use this tool to perform any document operation when no other specialized tool is available.
-This tool can also be used to READ/GET data from the document — make the last expression in the script be the value you want to retrieve, and it will be returned as the tool result.
-For example, to get the text of the first paragraph, write: Api.GetDocument().GetElement(0).GetText()
-The return value of the last expression will be the tool's output.`,
+This tool can also be used to READ/GET data from the document — use an explicit 'return' statement to send the value back as the tool result. When reading or inspecting content, do NOT modify the document — only use 'return' to send the value back.
+For example, to get the text of the first paragraph, write: return Api.GetDocument().GetElement(0).GetText()
+The value passed to 'return' will be the tool's output.`,
 		"parameters": {
 			"type": "object",
 			"properties": {
 				"code": {
 					"type": "string",
-					"description": `Valid JavaScript code using the OnlyOffice Document API to execute directly via eval. Rules:
+					"description": `Valid JavaScript code using the OnlyOffice Document API to execute directly. Rules:
 - Use only the OnlyOffice Document API (Api, ApiDocument, ApiParagraph, ApiRun, ApiTable, etc.)
 - Do NOT wrap the code in a function or IIFE — output only the statements to execute directly
+- SELF-CHECK before returning code: if this is a READ (not modifying the document), your code MUST contain a top-level 'return' statement; if it does not, rewrite to add one (e.g. oDoc.GetElement(0).GetText() → return oDoc.GetElement(0).GetText()). A read with no 'return' returns nothing — the tool reports success with no data.
 - Do NOT include any explanation, comments, or markdown — output raw JavaScript only
-- To GET/READ data: make the last expression the value you want to return (e.g. oDoc.GetElement(0).GetText())
+- To GET/READ data: use an explicit 'return' statement (e.g. return oDoc.GetElement(0).GetText()); do NOT insert the read content back into the document
 - To get the document object: let oDoc = Api.GetDocument()
 - To get elements count: oDoc.GetElementsCount()
 - To get element by index: oDoc.GetElement(index) — returns ApiParagraph or ApiTable
@@ -1187,16 +1188,13 @@ text.join('\\n');`
 
 	func.call = async function(params) {
 		Asc.scope.macroCode = params.code;
-		let returnValue = await Asc.Editor.callCommand(function() {
-			try {
-				var __result = eval(Asc.scope.macroCode);
-				if (__result !== undefined && __result !== null) {
-					return { onlyoffice_id_result: __result };
-				}
-			} catch(e) {
-				return { onlyoffice_id_error_message : e.name + ": " + e.message };
-			}
-		});
+		let __func;
+		try {
+			__func = new Function("try { var __r = (" + Asc.scope.macroCode + "); if (__r !== undefined && __r !== null) return { onlyoffice_id_result: __r }; } catch(e) { return { onlyoffice_id_error_message: e.name + ': ' + e.message }; }");
+		} catch (__e) {
+			__func = new Function("try { var __result = (function(){ " + Asc.scope.macroCode + " }).call(this); if (__result !== undefined && __result !== null) return { onlyoffice_id_result: __result }; } catch(e) { return { onlyoffice_id_error_message: e.name + ': ' + e.message }; }");
+		}
+		let returnValue = await Asc.Editor.callCommand(__func);
 
 		if (returnValue && returnValue.onlyoffice_id_error_message) {
 			throw new window.AgentState.ToolError(returnValue.onlyoffice_id_error_message);
@@ -4087,17 +4085,18 @@ HELPERS.slide.push((function(){
 		"name": "writeMacro",
 		"description": `Executes a JavaScript macro using the OnlyOffice Presentation API.
 Use this tool to perform any presentation operation when no other specialized tool is available.
-This tool can also be used to READ/GET data from the presentation — make the last expression in the script be the value you want to retrieve, and it will be returned as the tool result.
-For example, to get the number of slides, write: Api.GetPresentation().GetSlidesCount()
-The return value of the last expression will be the tool's output.`,
+This tool can also be used to READ/GET data from the presentation — use an explicit 'return' statement to send the value back as the tool result. When reading or inspecting content, do NOT modify the document — only use 'return' to send the value back.
+For example, to get the number of slides, write: return Api.GetPresentation().GetSlidesCount()
+The value passed to 'return' will be the tool's output.`,
 		"parameters": {
 			"type": "object",
 			"properties": {
 				"code": {
 					"type": "string",
-					"description": `Valid JavaScript code using the OnlyOffice Presentation API to execute directly via eval. Rules:
+					"description": `Valid JavaScript code using the OnlyOffice Presentation API to execute directly. Rules:
 - Use only the OnlyOffice Presentation API (Api, Api.GetPresentation(), etc.)
 - Do NOT wrap the code in a function or IIFE — output only the statements to execute directly
+- SELF-CHECK before returning code: if this is a READ (not modifying the document), your code MUST contain a top-level 'return' statement; if it does not, rewrite to add one (e.g. oDoc.GetElement(0).GetText() → return oDoc.GetElement(0).GetText()). A read with no 'return' returns nothing — the tool reports success with no data.
 - Do NOT include any explanation, comments, or markdown — output raw JavaScript only
 - To get the presentation object: let oPresentation = Api.GetPresentation()
 - To get the current slide: oPresentation.GetCurrentSlide()
@@ -4188,16 +4187,13 @@ oSlide.SetBackground(oFill);`
 
 	func.call = async function(params) {
 		Asc.scope.macroCode = params.code;
-		let returnValue = await Asc.Editor.callCommand(function() {
-			try {
-				var __result = eval(Asc.scope.macroCode);
-				if (__result !== undefined && __result !== null) {
-					return { onlyoffice_id_result: __result };
-				}
-			} catch(e) {
-				return { onlyoffice_id_error_message: e.name + ": " + e.message };
-			}
-		});
+		let __func;
+		try {
+			__func = new Function("try { var __r = (" + Asc.scope.macroCode + "); if (__r !== undefined && __r !== null) return { onlyoffice_id_result: __r }; } catch(e) { return { onlyoffice_id_error_message: e.name + ': ' + e.message }; }");
+		} catch (__e) {
+			__func = new Function("try { var __result = (function(){ " + Asc.scope.macroCode + " }).call(this); if (__result !== undefined && __result !== null) return { onlyoffice_id_result: __result }; } catch(e) { return { onlyoffice_id_error_message: e.name + ': ' + e.message }; }");
+		}
+		let returnValue = await Asc.Editor.callCommand(__func);
 
 		if (returnValue && returnValue.onlyoffice_id_error_message) {
 			throw new window.AgentState.ToolError(returnValue.onlyoffice_id_error_message);
@@ -8016,19 +8012,20 @@ HELPERS.cell.push((function(){
 		"name": "writeMacro",
 		"description": `Executes a JavaScript macro using the OnlyOffice Spreadsheet API.
 Use this tool to perform any spreadsheet operation when no other specialized tool is available.
-This tool can also be used to READ/GET data from the spreadsheet — make the last expression in the script be the value you want to retrieve, and it will be returned as the tool result.
-For example, to get the value of cell A1, write: Api.GetActiveSheet().GetRange("A1").GetValue()
-The return value of the last expression will be the tool's output.`,
+This tool can also be used to READ/GET data from the spreadsheet — use an explicit 'return' statement to send the value back as the tool result. When reading or inspecting content, do NOT modify the document — only use 'return' to send the value back.
+For example, to get the value of cell A1, write: return Api.GetActiveSheet().GetRange("A1").GetValue()
+The value passed to 'return' will be the tool's output.`,
 		"parameters": {
 			"type": "object",
 			"properties": {
 				"code": {
 					"type": "string",
-					"description": `Valid JavaScript code using the OnlyOffice Spreadsheet API to execute directly via eval. Rules:
+					"description": `Valid JavaScript code using the OnlyOffice Spreadsheet API to execute directly. Rules:
 - Use only the OnlyOffice Spreadsheet API (Api, ApiWorksheet, ApiRange, etc.)
 - Do NOT wrap the code in a function or IIFE — output only the statements to execute directly
+- SELF-CHECK before returning code: if this is a READ (not modifying the document), your code MUST contain a top-level 'return' statement; if it does not, rewrite to add one (e.g. oDoc.GetElement(0).GetText() → return oDoc.GetElement(0).GetText()). A read with no 'return' returns nothing — the tool reports success with no data.
 - Do NOT include any explanation, comments, or markdown — output raw JavaScript only
-- To GET/READ data: make the last expression the value you want to return (e.g. ws.GetRange("A1").GetValue())
+- To GET/READ data: use an explicit 'return' statement (e.g. return ws.GetRange("A1").GetValue()); do NOT insert the read content back into the document
 - To get the active sheet: var ws = Api.GetActiveSheet()
 - To get sheet by name: Api.GetSheet(sName)
 - To get all sheet names: Api.GetSheets() returns array of ApiWorksheet
@@ -8112,16 +8109,13 @@ values;`
 
 	func.call = async function(params) {
 		Asc.scope.macroCode = params.code;
-		let returnValue = await Asc.Editor.callCommand(function() {
-			try {
-				var __result = eval(Asc.scope.macroCode);
-				if (__result !== undefined && __result !== null) {
-					return { onlyoffice_id_result: __result };
-				}
-			} catch(e) {
-				return { onlyoffice_id_error_message: e.name + ": " + e.message };
-			}
-		});
+		let __func;
+		try {
+			__func = new Function("try { var __r = (" + Asc.scope.macroCode + "); if (__r !== undefined && __r !== null) return { onlyoffice_id_result: __r }; } catch(e) { return { onlyoffice_id_error_message: e.name + ': ' + e.message }; }");
+		} catch (__e) {
+			__func = new Function("try { var __result = (function(){ " + Asc.scope.macroCode + " }).call(this); if (__result !== undefined && __result !== null) return { onlyoffice_id_result: __result }; } catch(e) { return { onlyoffice_id_error_message: e.name + ': ' + e.message }; }");
+		}
+		let returnValue = await Asc.Editor.callCommand(__func);
 
 		if (returnValue && returnValue.onlyoffice_id_error_message) {
 			throw new window.AgentState.ToolError(returnValue.onlyoffice_id_error_message);


### PR DESCRIPTION

On a web-deployed Document Server, writeMacro (and generateDocx / changeParagraphStyle, same pattern) silently fail: WRITE requests report success but never modify the document; READ requests return no data.

(1) WRITE: the macro code is passed to Asc.Editor.callCommand as a nested eval inside the function body. Asc.plugin.callCommand serializes the function via toString(), and the editor core executes it through _safe_eval_closure (sdk-all-min.js), which wraps the string with Function.apply(... return eval(…)) and shadows the window formal parameter — a deliberate plugin sandbox. A side effect is that a nested eval() inside the function body returns undefined and never runs, so the macro silently no-ops. Verified by four probes: new Function(code) and executeCommand("command", code) mutate; nested eval(code) and nested new Function(code)() do not. The macro code must be the function body, not runtime-eval'd data.

(2) READ: replacing eval with new Function fixes WRITE, but a new Function body discards the last expression's value. The prompts and tool descriptions were built on eval's auto-return semantics, so a READ macro returned nothing.

Fix:
- helpers.js (3 sites): dual-form new Function wrapper. Expression form captures an IIFE / single expression; if new Function throws (multi-statement or has return), fall back to the statement form which captures a top-level return. try/catch + onlyoffice_id_result / onlyoffice_id_error_message contract preserved (safePluginEval swallows thrown errors).
- helperFuncs.js + helpers.js: align prompts and tool descriptions to the new execution model — read examples use explicit return; "last expression" -> "explicit return"; add READ/WRITE/CHAT decision rule (mutate only on explicit modify; reading never mutates), GENERATIVE rule (ask first on ambiguous "write content" requests), and SELF-CHECK rule (verify top-level return on READ macros).

Sandbox untouched; plugin isolation unchanged.