### PR TITLE
The plugin card closes when dragged

### DIFF
--- a/store/scripts/code.js
+++ b/store/scripts/code.js
@@ -689,7 +689,7 @@ function _onMessageTheme(message) {
 }
 function _onMessageMouseUp() {
 	if (pluginVersion > 1000005) {
-		MarketplacePluginService.closePluginCard();
+		//MarketplacePluginService.closePluginCard();
 		return;
 	}
 	let evt = document.createEvent('MouseEvents');


### PR DESCRIPTION
Comment out MarketplacePluginService.closePluginCard() in _onMessageMouseUp function